### PR TITLE
Statsite UDP for vagrant and updated install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "synthesize"
   config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   config.vm.network :forwarded_port, guest: 443, host: 8443
-  config.vm.network :forwarded_port, guest: 8125, host: 8125
+  config.vm.network :forwarded_port, guest: 8125, host: 8125, protocol: 'tcp'
+  config.vm.network :forwarded_port, guest: 8125, host: 8125, protocol: 'udp'
   config.vm.network :forwarded_port, guest: 2003, host: 22003
   config.vm.network :forwarded_port, guest: 2004, host: 22004
   config.vm.provision "shell", inline: "cd /vagrant; GRAPHITE_RELEASE=#{ENV['GRAPHITE_RELEASE']} ./install"

--- a/install
+++ b/install
@@ -26,7 +26,7 @@ fi
 apt-get update -y
 
 # Install package dependencies from apt
-RUNLEVEL=1 apt-get install -y libcairo2-dev libffi-dev pkg-config python-dev python-pip fontconfig apache2 libapache2-mod-wsgi git-core collectd memcached gcc g++ make scons
+RUNLEVEL=1 apt-get install -y libcairo2-dev libffi-dev pkg-config python-dev python-pip fontconfig apache2 libapache2-mod-wsgi git-core collectd memcached gcc g++ make
 
 # Download source repositories for Graphite/Carbon/Whisper and Statsite
 cd /usr/local/src

--- a/install
+++ b/install
@@ -39,7 +39,7 @@ git clone https://github.com/armon/statsite.git
 cd whisper; git checkout ${GRAPHITE_RELEASE}; python setup.py install
 cd ../carbon; git checkout ${GRAPHITE_RELEASE}; pip install -r requirements.txt; python setup.py install
 cd ../graphite-web; git checkout ${GRAPHITE_RELEASE}; pip install -r requirements.txt; python check-dependencies.py; python setup.py install
-cd ../statsite; make; cp statsite /usr/local/sbin/; cp sinks/graphite.py /usr/local/sbin/statsite-sink-graphite.py
+cd ../statsite; pip install --egg SCons; make; cp statsite /usr/local/sbin/; cp sinks/graphite.py /usr/local/sbin/statsite-sink-graphite.py
 
 # Install configuration files for Graphite/Carbon and Apache
 cp ${SYNTHESIZE_HOME}/templates/statsite/statsite.conf /etc/statsite.conf


### PR DESCRIPTION
Added the TCP and UDP protocol forwarding for Vagrant to fix a bug
where you can’t send UDP packets to the Vagrant box.
Also updated the install file to match the current recommended install
of statsite