### PR TITLE
In case install is run outside the root dir

### DIFF
--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 # Graphite installation script for Ubuntu 14.04
 # Jason Dixon <jason@dixongroup.net>
 
-SYNTHESIZE_HOME=$PWD
+SYNTHESIZE_HOME=$( cd "$( dirname "$0" )" && pwd )
 UBUNTU_RELEASE=`lsb_release -a 2>/dev/null | grep '^Descrip' | cut -s -f 2`
 
 GRAPHITE_HOME='/opt/graphite'


### PR DESCRIPTION
`sudo bash synthesize/install` will still result
in SYNTHESIZE_HOME set to the same directory as if
run as directed `cd synthesize` `sudo bash install`

( for those of us that don't read *all* the directions :smile: ) 