### PR TITLE
updates Ubuntu release check to match hosted Vagrant box image

### DIFF
--- a/install
+++ b/install
@@ -13,7 +13,7 @@ if [ -z $GRAPHITE_RELEASE ]; then
     GRAPHITE_RELEASE='0.9.13-pre1'
 fi
 
-if [[ ! $UBUNTU_RELEASE =~ 'Ubuntu 14.04.1 LTS' ]]; then
+if [[ ! $UBUNTU_RELEASE =~ 'Ubuntu 14.04.2 LTS' ]]; then
   echo "Sorry, this is only supported for Ubuntu Linux 14.04."
   exit 1
 fi

--- a/install
+++ b/install
@@ -13,7 +13,7 @@ if [ -z $GRAPHITE_RELEASE ]; then
     GRAPHITE_RELEASE='0.9.13-pre1'
 fi
 
-if [[ ! $UBUNTU_RELEASE =~ 'Ubuntu 14.04.2 LTS' ]]; then
+if [[ ! $UBUNTU_RELEASE =~ 'Ubuntu 14.04' ]]; then
   echo "Sorry, this is only supported for Ubuntu Linux 14.04."
   exit 1
 fi


### PR DESCRIPTION
It appears that the Vagrant box image currently returned from the URL https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box, and referenced in the Vagrant file, is Ubuntu 14.04.2 LTS.  This caused the version check in ./install to fail.