### PR TITLE
Support vmware provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8125, host: 8125, protocol: 'udp'
   config.vm.network :forwarded_port, guest: 2003, host: 22003
   config.vm.network :forwarded_port, guest: 2004, host: 22004
-  graphite_version = ENV['GRAPHITE_RELEASE'].nil? ? '0.9.13-pre1' : ENV['GRAPHITE_RELEASE']
+  graphite_version = ENV['GRAPHITE_RELEASE'].nil? ? '0.9.14' : ENV['GRAPHITE_RELEASE']
   config.vm.provision "shell", inline: "cd /vagrant; GRAPHITE_RELEASE=#{graphite_version} ./install"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "synthesize"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "mayflower/trusty64-puppet3"
   config.vm.network :forwarded_port, guest: 443, host: 8443
   config.vm.network :forwarded_port, guest: 8125, host: 8125, protocol: 'tcp'
   config.vm.network :forwarded_port, guest: 8125, host: 8125, protocol: 'udp'


### PR DESCRIPTION
As requested by @armon in #34. Also bump the default `GRAPHITE_VERSION` in anticipation of the upcoming release.