### PR TITLE
Match WSGIDaemonProcess with graphite-web example

### DIFF
--- a/templates/apache/graphite.conf
+++ b/templates/apache/graphite.conf
@@ -6,7 +6,7 @@
   CustomLog /opt/graphite/storage/log/apache2/access.log combined
   ErrorLog /opt/graphite/storage/log/apache2/error.log
 
-  WSGIDaemonProcess graphiteweb python-path=/opt/graphite:/opt/graphite/lib/python2.7/site-packages
+  WSGIDaemonProcess graphiteweb python-path=/opt/graphite:/opt/graphite/lib/python2.7/site-packages processes=5 threads=5 display-name='%{GROUP}' inactivity-timeout=120
   WSGIProcessGroup graphiteweb
   WSGIApplicationGroup %{GLOBAL}
   WSGIImportScript /opt/graphite/conf/graphite.wsgi process-group=graphiteweb application-group=%{GLOBAL}


### PR DESCRIPTION
The included apache configuration of WSGIDaemonProcess is very limited.
This commit adopts the example settings from graphite-web[1], which
serves as a bread crumb for tuning this configuration for deployments
with significant read traffic.

[1] https://github.com/graphite-project/graphite-web/blob/20d443b7158b3e601b0f77279247804ca7b4fc3a/examples/example-graphite-vhost.conf#L31