### PR TITLE
fix statsite python cmd

### DIFF
--- a/templates/statsite/statsite.conf
+++ b/templates/statsite/statsite.conf
@@ -6,7 +6,7 @@ log_level = INFO
 flush_interval = 10
 timer_eps = 0.01
 set_eps = 0.02
-stream_cmd = python /usr/local/sbin/statsite-sink-graphite.py localhost 2003
+stream_cmd = python3 /usr/local/sbin/statsite-sink-graphite.py localhost 2003
 input_counter = numStats
 daemonize = 0
 


### PR DESCRIPTION
Fix the statsite template to use Python3.

refs #79 